### PR TITLE
Fix: Prevent 'Total # in Home' field from listing NaN 

### DIFF
--- a/src/components/sub-components/application/home.vue
+++ b/src/components/sub-components/application/home.vue
@@ -132,12 +132,7 @@ export default {
   },
   computed: {
     calcFamily(){
-      if (this.familyInfo.numAdults == undefined || this.familyInfo.numAdults == "") {
-        return null
-      }
-      else {
-        return Number(this.familyInfo.numAdults) + Number(this.familyInfo.numKids)
-      }
+        return Number(this.familyInfo.numAdults || 0) + Number(this.familyInfo.numKids || 0)
     },
     phoneTypes(){
       return this.$store.getters.getPhoneTypes

--- a/src/components/sub-components/familyInfo/home.vue
+++ b/src/components/sub-components/familyInfo/home.vue
@@ -110,7 +110,7 @@ export default {
   },
   computed: {
     calcFamily(){
-      return Number(this.familyInfo.numAdults) + Number(this.familyInfo.numKids)
+        return Number(this.familyInfo.numAdults || 0) + Number(this.familyInfo.numKids || 0)
     },
     phoneTypes(){
       return this.$store.getters.getPhoneTypes


### PR DESCRIPTION
- **Problem**:`this.familyInfo.numKid` is initially `undefined` so when you try to add it to `this.family.numAdults`, it results in NaN
<img width="614" alt="Screen Shot 2020-10-05 at 11 16 50 PM" src="https://user-images.githubusercontent.com/40472917/95165475-e24ec500-0760-11eb-909a-def9cbeb5294.png">

- I also noticed that if `this.familyInfo.numAdults` is blank, but `this.familyInfo.numKid` is defined, the total number remains blank, but I expect it to change accordingly. (Unless this was some "form validation", as you number of adults is a required field and you wanted to hide the total until that field is filled?)
<img width="626" alt="Screen Shot 2020-10-05 at 11 10 49 PM" src="https://user-images.githubusercontent.com/40472917/95165408-c5b28d00-0760-11eb-96b0-0ab7c1368f41.png">

- **Solution**: this fix sets a default number for both variables, so that it will add accordingly as long as both fields are valid:

Default: Total # is set to 0 upon render: 
<img width="613" alt="Screen Shot 2020-10-05 at 11 12 21 PM" src="https://user-images.githubusercontent.com/40472917/95165261-7f5d2e00-0760-11eb-960c-9c36708f586e.png">

Expected Results after change: 
<img width="608" alt="Screen Shot 2020-10-05 at 11 15 27 PM" src="https://user-images.githubusercontent.com/40472917/95165364-b0d5f980-0760-11eb-844e-d987e80cd7e0.png">

<img width="632" alt="Screen Shot 2020-10-05 at 11 12 28 PM" src="https://user-images.githubusercontent.com/40472917/95165273-81bf8800-0760-11eb-94b8-54f2eb2d8527.png">



Fix for Issue #18