### PR TITLE
Issue 23: Migrate icons to font awesome 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "firebase": "^7.22.1",
     "html2pdf.js": "^0.9.2",
     "json2csv": "^4.5.4",
-    "material-design-icons-iconfont": "^4.0.5",
     "moment": "^2.29.0",
     "roboto-fontface": "*",
     "vue": "^2.6.12",
@@ -22,6 +21,7 @@
     "vuex": "^3.5.1"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.1",
     "@vue/cli-plugin-babel": "^3.12.1",
     "@vue/cli-service": "^3.12.1",
     "@vue/eslint-config-prettier": "^4.0.1",

--- a/src/components/about.vue
+++ b/src/components/about.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>info</v-icon>
+        <v-icon left>fas fa-info-circle</v-icon>
         About this Web App...
       </v-toolbar-title>
     </v-toolbar>

--- a/src/components/accountDeactivated.vue
+++ b/src/components/accountDeactivated.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar color="primary" dark>
       <v-toolbar-title>
-        <v-icon left>not_interested</v-icon>
+        <v-icon left>fas fa-ban</v-icon>
         ACCOUNT INACTIVE
       </v-toolbar-title>
     </v-toolbar>

--- a/src/components/admin.vue
+++ b/src/components/admin.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>person_outline</v-icon>
+        <v-icon left>far fa-user</v-icon>
         Admin Control Panel
       </v-toolbar-title>
     </v-toolbar>
@@ -15,7 +15,7 @@
       slider-color="secondary"
     >
       <v-tab>
-        <v-icon left>group</v-icon>
+        <v-icon left>fas fa-user-friends</v-icon>
         Users
       </v-tab>
       <v-tab>
@@ -27,7 +27,7 @@
           <v-layout row>
             <v-spacer></v-spacer>
             <v-btn color="accent2" outline @click="addUserDialog = true" round outline small>
-              <v-icon left>add_circle</v-icon>
+              <v-icon left>fas fa-plus-circle</v-icon>
               Add User
             </v-btn>
           </v-layout>
@@ -54,17 +54,17 @@
                     <td class="subheading">{{ props.item.role }}</td>
                     <td class="text-xs-center">
                       <v-btn color="accent" small icon @click="resetPassword(props.item)">
-                        <v-icon small>settings_backup_restore</v-icon>
+                        <v-icon small>fas fa-play</v-icon>
                       </v-btn>
                     </td>
                     <td class="text-xs-center">
                       <v-btn color="accent" small icon @click="changeRole(props.item)">
-                        <v-icon small>security</v-icon>
+                        <v-icon small>fas fa-shield-alt</v-icon>
                       </v-btn>
                     </td>
                     <td class="text-xs-center">
                       <v-btn color="accent" small icon @click="deactivateUser(props.item)">
-                        <v-icon small>not_interested</v-icon>
+                        <v-icon small>fas fa-ban</v-icon>
                       </v-btn>
                     </td>
                   </tr>
@@ -85,7 +85,7 @@
                     <td>{{ props.item.role }}</td>
                     <td class="text-xs-center">
                       <v-btn color="accent" small icon @click="activateUser(props.item)">
-                        <v-icon small>refresh</v-icon>
+                        <v-icon small>fas fa-redo</v-icon>
                       </v-btn>
                     </td>
                   </tr>

--- a/src/components/admin/activateUser.vue
+++ b/src/components/admin/activateUser.vue
@@ -1,14 +1,14 @@
 <template lang="html">
   <v-card>
     <v-toolbar color="primary" dense dark>
-      <v-icon>person_add</v-icon>
+      <v-icon>fas fa-user-plus</v-icon>
       <v-toolbar-title>
         Confirm user activation:
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" outline icon small @click="close()">
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -20,11 +20,11 @@
       </p>
       <v-layout row wrap justify-space-around>
         <v-btn color="primary" outline @click="activateUser()" outline round>
-          <v-icon left>check_circle</v-icon>
+         <v-icon left>fas fa-check-circle</v-icon>
           Yes
         </v-btn>
         <v-btn color="red darken-4" dark @click="close()" outline round>
-          <v-icon left>close</v-icon>
+          <v-icon left>fas fa-times</v-icon>
           No
         </v-btn>
       </v-layout>

--- a/src/components/admin/addUser.vue
+++ b/src/components/admin/addUser.vue
@@ -1,14 +1,14 @@
 <template lang="html">
   <v-card>
     <v-toolbar color="primary" dense dark>
-      <v-icon>person_add</v-icon>
+      <v-icon>fas fa-user-plus</v-icon>
       <v-toolbar-title>
         Add User
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" outline icon small @click="close()">
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -33,7 +33,8 @@
         <v-flex xs12 class="text-xs-right">
           <v-tooltip top>
             <v-btn color="primary" outline @click="createUser()" slot="activator" :disabled="checkUser" round>
-              <v-icon left>add_circle_outline</v-icon>
+              <!-- For this icon it needs the pro version of Awesome Fonts -->
+              <v-icon left>fas fa-plus-circle</v-icon>
               Create User
             </v-btn>
             <span>Once you have enetered an email and selected a role you can create the user.</span>

--- a/src/components/admin/changeRole.vue
+++ b/src/components/admin/changeRole.vue
@@ -1,14 +1,14 @@
 <template lang="html">
   <v-card>
     <v-toolbar color="primary" dense dark>
-      <v-icon>security</v-icon>
+      <v-icon>fas fa-shield-alt</v-icon>
       <v-toolbar-title>
         Change User Role
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" outline icon small @click="close()">
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -26,7 +26,7 @@
         </v-flex>
         <v-flex xs12 class="text-xs-right">
           <v-btn color="primary" outline @click="saveChanges()" round outline>
-            <v-icon left>save</v-icon>
+            <v-icon left>fas fa-save</v-icon>
             Save Changes
           </v-btn>
         </v-flex>

--- a/src/components/admin/dbVariables.vue
+++ b/src/components/admin/dbVariables.vue
@@ -20,7 +20,7 @@
                   </v-flex>
                   <v-flex xs2>
                     <v-btn color="secondary" outline small icon @click="justTheTip = !justTheTip">
-                      <v-icon small>close</v-icon>
+                      <v-icon small>fas fa-times</v-icon>
                     </v-btn>
                   </v-flex>
                 </v-layout>

--- a/src/components/admin/deactivateUser.vue
+++ b/src/components/admin/deactivateUser.vue
@@ -2,13 +2,13 @@
   <v-card>
     <v-toolbar color="primary" dense dark>
       <v-toolbar-title>
-        <v-icon>person_add</v-icon>
+        <v-icon>fas fa-user-plus</v-icon>
         Confirm user deactivation:
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" outline icon small @click="close()">
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -20,11 +20,11 @@
       </p>
       <v-layout row wrap justify-space-around>
         <v-btn color="primary" outline @click="deactivateUser()" round outline>
-          <v-icon left>check_circle</v-icon>
+         <v-icon left>fas fa-check-circle</v-icon>
           Yes
         </v-btn>
         <v-btn color="red darken-4" dark @click="close()" round outline>
-          <v-icon left>close</v-icon>
+          <v-icon left>fas fa-times</v-icon>
           No
         </v-btn>
       </v-layout>

--- a/src/components/admin/resetPass.vue
+++ b/src/components/admin/resetPass.vue
@@ -1,14 +1,14 @@
 <template lang="html">
   <v-card>
     <v-toolbar color="primary" dense dark>
-      <v-icon>settings_backup_restore</v-icon>
+      <v-icon>fas fa-undo</v-icon>
       <v-toolbar-title>
         Confirm reset password
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" outline icon small @click="close()">
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -20,11 +20,11 @@
       </p>
       <v-layout row wrap justify-space-around>
         <v-btn color="primary" outline @click="resetPassword()" round outline>
-          <v-icon left>check_circle</v-icon>
+         <v-icon left>fas fa-check-circle</v-icon>
           Yes
         </v-btn>
         <v-btn color="red darken-4" dark @click="close()" round outline>
-          <v-icon left>close</v-icon>
+          <v-icon left>fas fa-times</v-icon>
           No
         </v-btn>
       </v-layout>

--- a/src/components/dashboard.vue
+++ b/src/components/dashboard.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>dashboard</v-icon>
+        <v-icon left>fas fa-columns</v-icon>
         Dashboard
       </v-toolbar-title>
     </v-toolbar>

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -2,7 +2,7 @@
   <v-card height="500px">
     <v-toolbar color="secondary" dark flat>
       <v-toolbar-title>
-        <v-icon left>home</v-icon>
+        <v-icon left>fas fa-home</v-icon>
         Welcome
       </v-toolbar-title>
     </v-toolbar>
@@ -23,7 +23,7 @@
       <v-layout row align-center>
         <v-flex xs6 offset-xs3>
           <v-btn color="primary" outline block large round v-if="!getUser" to="/apply" class="title">
-            <v-icon left>edit</v-icon>
+            <v-icon left>fas fa-pen</v-icon>
             Fill Out The Application Online
           </v-btn>
         </v-flex>

--- a/src/components/newCase.vue
+++ b/src/components/newCase.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>add_circle</v-icon>
+        <v-icon left>fas fa-plus-circle</v-icon>
         Create a New Case
       </v-toolbar-title>
     </v-toolbar>

--- a/src/components/providers.vue
+++ b/src/components/providers.vue
@@ -13,7 +13,7 @@
       <v-layout row wrap>
         <v-flex xs12 class="text-xs-right">
           <v-btn color="primary" @click="addProvider()" outline round small>
-            <v-icon left>add_circle</v-icon>
+            <v-icon left>fas fa-plus-circle</v-icon>
             Add Provider
           </v-btn>
         </v-flex>
@@ -33,12 +33,12 @@
             <td width="40%" class="subheading">{{ props.item.typeOfProvider.toString().replace(",", " , ") }}</td>
             <td class="text-xs-center">
               <v-btn color="accent" small icon @click="editProvider(props.item)">
-                <v-icon small>edit</v-icon>
+                <v-icon small>fas fa-pen</v-icon>
               </v-btn>
             </td>
             <td class="text-xs-center" v-if="getUserRole == 'admin'">
               <v-btn color="accent" small icon @click="confirmDelProvider(props.item)" outline>
-                <v-icon small>delete</v-icon>
+                <v-icon small>fas fa-trash</v-icon>
               </v-btn>
             </td>
           </tr>
@@ -54,7 +54,7 @@
       <v-card>
         <v-toolbar color="primary" dark dense>
           <v-toolbar-title>
-            <v-icon left>check_circle</v-icon>
+            <v-icon left>fas fa-check-circle</v-icon>
             Confirm Provider Removal:
           </v-toolbar-title>
         </v-toolbar>
@@ -67,11 +67,11 @@
           <br>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" outline @click="delProvider()" round outline>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" @click="delDialog = false" dark round outline>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/reports.vue
+++ b/src/components/reports.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>view_carousel</v-icon>
+        <v-icon left>fas fa-folder</v-icon>
         Reports
       </v-toolbar-title>
     </v-toolbar>
@@ -135,7 +135,7 @@ export default {
         },
         {
           btnText   : "Dowload All Data",
-          icon      : "cloud_download",
+          icon      : "fas fa-cloud-download-alt",
           shortCode : "excel",
           tooltip   : "Download all case data in Excel format.",
           disabled  : false

--- a/src/components/searchCase.vue
+++ b/src/components/searchCase.vue
@@ -2,13 +2,13 @@
   <v-card>
     <v-toolbar flat>
       <v-toolbar-title>
-        <v-icon left>search</v-icon>
+        <v-icon left>fas fa-search</v-icon>
         Case Search:
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <!-- <v-toolbar-items> -->
         <v-btn color="accent2" outline dark small @click="confirmReset()" round outline>
-          <v-icon left>undo</v-icon>
+          <v-icon left>fas fa-undo</v-icon>
           Reset Search
         </v-btn>
       <!-- </v-toolbar-items> -->
@@ -40,7 +40,7 @@
             </v-layout>
             <v-layout row justify-end>
               <v-btn color="primary" @click="searchCases()" round outline small>
-                <v-icon left>search</v-icon>
+                <v-icon left>fas fa-search</v-icon>
                 Search
               </v-btn>
             </v-layout>
@@ -78,12 +78,12 @@
               </td>
               <td width="10%" class="pa-0 ma-0 text-xs-center">
                 <v-btn color="primary" @click="selectCase(props.item)" icon round outline small>
-                  <v-icon small>edit</v-icon>
+                  <v-icon small>fas fa-pen</v-icon>
                 </v-btn>
               </td>
               <td width="10%" class="pa-0 ma-0 text-xs-center" v-if="getUserRole == 'admin'">
                 <v-btn color="red darken-3" small icon @click="confirmDel(props.item)" outline>
-                  <v-icon small>delete</v-icon>
+                  <v-icon small>fas fa-trash</v-icon>
                 </v-btn>
               </td>
             </template>
@@ -100,7 +100,7 @@
       <v-card>
         <v-toolbar color="primary" dark dense>
           <v-toolbar-title>
-            <v-icon left>check_circle</v-icon>
+           <v-icon left>fas fa-check-circle</v-icon>
             Confirm Removal of Case:{{caseRemove.caseId}}
           </v-toolbar-title>
         </v-toolbar>
@@ -113,11 +113,11 @@
           <br>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" outline @click="delCase()" round outline>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" @click="caseRemoveDialog = false" dark round outline>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/sub-components/application/children.vue
+++ b/src/components/sub-components/application/children.vue
@@ -8,7 +8,7 @@
     <v-card-text>
       <div class="text-xs-right">
         <v-btn color="primary" @click="addChild()" round outline small>
-          <v-icon>add</v-icon>
+          <v-icon small >fas fa-plus</v-icon>
           Add Child
         </v-btn>
       </div>
@@ -17,7 +17,7 @@
           Child {{`0${index+1}`}}
           <v-spacer></v-spacer>
           <v-btn color="primary" small icon outline @click="confirmDel(index)">
-            <v-icon color="primary">close</v-icon>
+            <v-icon color="primary" small>fas fa-times</v-icon>
           </v-btn>
           <!-- DELETE CHILD RECORD CONFIRM DIALOG -->
           <v-dialog
@@ -36,11 +36,11 @@
               <v-card-text>
                 <v-layout row justify-space-around>
                   <v-btn color="primary" @click="removeChildRecord()" round outline>
-                    <v-icon left>check</v-icon>
+                    <v-icon left small>fas fa-check</v-icon>
                     Yes
                   </v-btn>
                   <v-btn color="red darken-3" outline @click="confirmChildDel = !confirmChildDel" round>
-                    <v-icon left>close</v-icon>
+                    <v-icon left small>fas fa-times</v-icon>
                     No
                   </v-btn>
                 </v-layout>

--- a/src/components/sub-components/application/finances.vue
+++ b/src/components/sub-components/application/finances.vue
@@ -13,7 +13,7 @@
         <v-card-title>
           <v-spacer></v-spacer>
           <v-btn color="primary" outline @click="addIncome(true)" round outline small>
-            <v-icon left>add_circle</v-icon>
+            <v-icon left>fas fa-plus-circle</v-icon>
             Add Applicant Income
           </v-btn>
         </v-card-title>
@@ -47,7 +47,7 @@
                 </v-flex>
                 <v-flex xs1 class="text-xs-right">
                   <v-btn color="primary" icon outline small @click="confirmDelete('app', index)">
-                    <v-icon small>delete</v-icon>
+                    <v-icon small>fas fa-trash</v-icon>
                   </v-btn>
                 </v-flex>
               </v-layout>
@@ -62,7 +62,7 @@
         <v-card-title primary-title>
           <v-spacer></v-spacer>
           <v-btn color="primary" outline @click="addIncome(false)" round outline small>
-            <v-icon left>add_circle</v-icon>
+            <v-icon left>fas fa-plus-circle</v-icon>
             Add Co-Applicant Income
           </v-btn>
         </v-card-title>
@@ -96,7 +96,7 @@
                 </v-flex>
                 <v-flex xs1 class="text-xs-right">
                   <v-btn color="primary" icon outline small @click="confirmDelete('coapp', index)">
-                    <v-icon small>delete</v-icon>
+                    <v-icon small>fas fa-trash</v-icon>
                   </v-btn>
                 </v-flex>
               </v-layout>
@@ -128,7 +128,7 @@
           <v-toolbar-title>Add Income for {{addIncomePerson ? "Applicant" : "Co-Applicant"}}:</v-toolbar-title>
           <v-spacer></v-spacer>
           <v-btn color="white" outline icon small @click="addIncomeDialog = false">
-            <v-icon>close</v-icon>
+            <v-icon>fas fa-times</v-icon>
           </v-btn>
         </v-toolbar>
         <v-card-text>
@@ -180,7 +180,7 @@
                 <v-flex xs5>
                   <v-text-field
                     label="Average:"
-                    prepend-inner-icon="attach_money"
+                    prepend-inner-icon="fas fa-dollar-sign"
                     readonly
                     v-model="getTempAvg"
                   ></v-text-field>
@@ -188,7 +188,7 @@
                 <v-flex xs5 offset-xs1>
                   <v-text-field
                     label="Annual:"
-                    prepend-inner-icon="attach_money"
+                    prepend-inner-icon="fas fa-dollar-sign"
                     v-model="getTempAnnual"
                     readonly
                   ></v-text-field>
@@ -200,7 +200,7 @@
         <v-layout row wrap>
           <v-spacer></v-spacer>
           <v-btn color="primary" small @click="saveIncomeItem()" outline round>
-            <v-icon left>save</v-icon>
+            <v-icon left>fas fa-save</i></v-icon>
             Save Income
           </v-btn>
         </v-layout>
@@ -220,11 +220,11 @@
         <v-card-text>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" @click="delRecord()" round outline>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" @click="deleteDialog = false" dark round outline>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/sub-components/attendanceLog.vue
+++ b/src/components/sub-components/attendanceLog.vue
@@ -3,7 +3,7 @@
     <v-layout row wrap>
       <v-flex xs12 class="text-xs-right">
         <v-btn color="primary" outline small @click="addRecord()" round>
-          <v-icon left>add_circle</v-icon>
+          <v-icon left>fas fa-plus-circle</v-icon>
           Add Attendance Record
         </v-btn>
       </v-flex>
@@ -13,7 +13,7 @@
         <v-layout row wrap>
           <v-flex xs12 class="text-xs-right">
             <v-btn color="primary" icon outline small @click="confirmDelete(index)">
-              <v-icon>close</v-icon>
+              <v-icon>fas fa-times</v-icon>
             </v-btn>
           </v-flex>
         </v-layout>
@@ -90,11 +90,11 @@
         <v-card-text>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" @click="deleteRecord()" round outline>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" dark @click="deleteDialog = false" round outline>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/sub-components/caseInfo.vue
+++ b/src/components/sub-components/caseInfo.vue
@@ -3,7 +3,7 @@
     <v-card-text>
       <v-card flat>
         <v-alert color="accent2" :value="true" dense dismissible outline>
-          <v-icon left>save</v-icon>
+          <v-icon left>fas fa-save</v-icon>
           For convenience, CTRL + Q on your keyboard will save.
         </v-alert>
         <v-toolbar color="primary" dark dense flat>
@@ -60,7 +60,7 @@
               <v-toolbar-title>Select Current Case Status</v-toolbar-title>
               <v-spacer></v-spacer>
               <v-btn color="white" small outline icon @click="statusModal = false">
-                <v-icon>close</v-icon>
+                <v-icon>fas fa-times</v-icon>
               </v-btn>
             </v-toolbar>
             <v-card-text>
@@ -98,7 +98,7 @@
               <v-layout row wrap>
                 <v-flex xs12 class="text-xs-right">
                   <v-btn color="primary" @click="saveStatus()" round small outline>
-                    <v-icon left>check_circle_outline</v-icon>
+                    <v-icon left>far fa-check-circle</v-icon>
                     Set Status
                   </v-btn>
                 </v-flex>
@@ -158,7 +158,7 @@
     <v-layout row wrap>
       <v-flex xs12 class="text-xs-right">
         <v-btn color="primary" @click="saveCase()" round outline small>
-          <v-icon left>save</v-icon>
+          <v-icon left>fas fa-save</v-icon>
           Save Case Information
         </v-btn>
       </v-flex>

--- a/src/components/sub-components/confirmLeave.vue
+++ b/src/components/sub-components/confirmLeave.vue
@@ -18,11 +18,11 @@
       <br>
       <v-layout row wrap justify-space-around>
         <v-btn color="primary" outline @click="leave()" round outline>
-          <v-icon left>check</v-icon>
+          <v-icon left>fas fa-check</v-icon>
           Yes
         </v-btn>
         <v-btn color="red darken-4" dark @click="cancel()" round outline>
-          <v-icon left>close</v-icon>
+          <v-icon left>fas fa-times</v-icon>
           No!
         </v-btn>
       </v-layout>

--- a/src/components/sub-components/dateSelect.vue
+++ b/src/components/sub-components/dateSelect.vue
@@ -65,7 +65,7 @@
     </v-flex>
     <v-flex xs12 class="text-xs-right">
       <v-btn color="primary" outline round small :disabled="readyToGenerate" @click="setDates()">
-        <v-icon left>cached</v-icon>
+        <v-icon left>fas fa-sync</v-icon>
         Generate Report
       </v-btn>
     </v-flex>

--- a/src/components/sub-components/editProvider.vue
+++ b/src/components/sub-components/editProvider.vue
@@ -5,7 +5,7 @@
       <v-spacer></v-spacer>
       <v-toolbar-items>
         <v-btn color="white" icon small @click="close()" outline>
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar-items>
     </v-toolbar>
@@ -119,11 +119,11 @@
     </v-card-text>
     <v-layout row wrap justify-space-around align-center>
       <v-btn color="primary" outline @click="saveProvider()" round outline small>
-        <v-icon left>save</v-icon>
+        <v-icon left>fas fa-save</v-icon>
         Save Provider
       </v-btn>
       <v-btn color="red darken-4" dark @click="close()" round outline small>
-        <v-icon left>close</v-icon>
+        <v-icon left>fas fa-times</v-icon>
         Cancel
       </v-btn>
     </v-layout>

--- a/src/components/sub-components/familyInfo/children.vue
+++ b/src/components/sub-components/familyInfo/children.vue
@@ -3,7 +3,7 @@
     <v-card-text>
       <div class="text-xs-right">
         <v-btn color="primary" @click="addChild()" round outline small>
-          <v-icon>add</v-icon>
+          <v-icon>fas fa-plus</v-icon>
           Add Child
         </v-btn>
       </div>
@@ -12,7 +12,7 @@
           Child {{`0${index+1}`}}
           <v-spacer></v-spacer>
           <v-btn color="primary" small icon outline @click="confirmDel(index)">
-            <v-icon color="primary">close</v-icon>
+            <v-icon color="primary">fas fa-times</v-icon>
           </v-btn>
           <!-- DELETE CHILD RECORD CONFIRM DIALOG -->
           <v-dialog
@@ -31,11 +31,11 @@
               <v-card-text>
                 <v-layout row justify-space-around>
                   <v-btn color="primary" @click="removeChildRecord()" round outline>
-                    <v-icon left>check</v-icon>
+                    <v-icon left>fas fa-check</v-icon>
                     Yes
                   </v-btn>
                   <v-btn color="red darken-3" outline @click="confirmChildDel = !confirmChildDel" round>
-                    <v-icon left>close</v-icon>
+                    <v-icon left>fas fa-times</v-icon>
                     No
                   </v-btn>
                 </v-layout>

--- a/src/components/sub-components/familyInfo/income.vue
+++ b/src/components/sub-components/familyInfo/income.vue
@@ -11,7 +11,7 @@
             <v-card-title>
               <v-spacer></v-spacer>
               <v-btn color="primary" outline @click="addIncome(true)" round outline small>
-                <v-icon left>add_circle</v-icon>
+                <v-icon left>fas fa-plus-circle</v-icon>
                 Add Applicant Income
               </v-btn>
             </v-card-title>
@@ -45,7 +45,7 @@
                     </v-flex>
                     <v-flex xs1 class="text-xs-right">
                       <v-btn color="primary" icon outline small @click="confirmDelete('app', index)">
-                        <v-icon small>delete</v-icon>
+                        <v-icon small>fas fa-trash</v-icon>
                       </v-btn>
                     </v-flex>
                   </v-layout>
@@ -64,7 +64,7 @@
             <v-card-title primary-title>
               <v-spacer></v-spacer>
               <v-btn color="primary" outline @click="addIncome(false)" round outline small>
-                <v-icon left>add_circle</v-icon>
+                <v-icon left>fas fa-plus-circle</v-icon>
                 Add Applicant Income
               </v-btn>
             </v-card-title>
@@ -98,7 +98,7 @@
                     </v-flex>
                     <v-flex xs1 class="text-xs-right">
                       <v-btn color="primary" icon outline small @click="confirmDelete('coapp', index)">
-                        <v-icon small>delete</v-icon>
+                        <v-icon small>fas fa-trash</v-icon>
                       </v-btn>
                     </v-flex>
                   </v-layout>
@@ -132,7 +132,7 @@
           <v-toolbar-title>Add Income for {{addIncomePerson ? "Applicant" : "Co-Applicant"}}:</v-toolbar-title>
           <v-spacer></v-spacer>
           <v-btn color="white" outline icon small @click="addIncomeDialog = false">
-            <v-icon>close</v-icon>
+            <v-icon>fas fa-times</v-icon>
           </v-btn>
         </v-toolbar>
         <v-card-text>
@@ -204,7 +204,7 @@
         <v-layout row wrap>
           <v-spacer></v-spacer>
           <v-btn color="primary" small @click="saveIncomeItem()" outline round>
-            <v-icon left>save</v-icon>
+            <v-icon left>fas fa-save</v-icon>
             Save Income
           </v-btn>
         </v-layout>
@@ -224,11 +224,11 @@
         <v-card-text>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" @click="delRecord()" round outline>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" @click="deleteDialog = false" dark round outline>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/sub-components/header.vue
+++ b/src/components/sub-components/header.vue
@@ -8,11 +8,11 @@
       <v-spacer></v-spacer>
       <!-- CHANGE BUTTON BASED ON WHETHER A USER IS LOGGED IN OR OUT -->
       <v-btn v-if="getUser == null" small color="white" outline @click="activateSignIn" round>
-        <v-icon left small>navigate_next</v-icon>
+        <v-icon left small>fas fa-chevron-right</v-icon>
         Sign In
       </v-btn>
       <v-btn v-else small color="white" outline @click="activateSignOut" round>
-        <v-icon left>navigate_before</v-icon>
+        <v-icon left>fas fa-chevron-left</v-icon>
         Sign Out
       </v-btn>
     </v-toolbar>

--- a/src/components/sub-components/letters.vue
+++ b/src/components/sub-components/letters.vue
@@ -11,19 +11,19 @@
         <br>
         <v-layout row wrap justify-space-around>
           <v-btn outline color="primary" @click="openPrintDialog('letter-accepted')" round small outline>
-            <v-icon left>check</v-icon>
+            <v-icon left>fas fa-check</v-icon>
             Accepted
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('letter-waiting')" round small outline>
-            <v-icon left>access_time</v-icon>
+            <v-icon left>far fa-clock</v-icon>
             Waiting List
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('letter-pending')" round small outline>
-            <v-icon left>hourglass_empty</v-icon>
+            <v-icon left>far fa-hourglass</v-icon>
             Pending
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('letter-ineligible')" round small outline>
-            <v-icon left>not_interested</v-icon>
+            <v-icon left>fas fa-ban</v-icon>
             Ineligible
           </v-btn>
         </v-layout>
@@ -40,7 +40,7 @@
             PAPA Letter
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('papa-form')" round small outline>
-            <v-icon left>description</v-icon>
+            <v-icon left>fas fa-file-alt</v-icon>
             Pre-PAPA
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('papa-final')" round small outline>
@@ -57,15 +57,15 @@
         <br>
         <v-layout row wrap justify-space-around>
           <v-btn outline color="primary" @click="openPrintDialog('attendance')" round small outline>
-            <v-icon left>calendar_today</v-icon>
+            <v-icon left>fas fa-calendar-week</v-icon>
             Attendance Voucher
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('case-report')" round small outline>
-            <v-icon left>description</v-icon>
+            <v-icon left>fas fa-file-alt</v-icon>
             Full Case Report
           </v-btn>
           <v-btn outline color="primary" @click="openPrintDialog('termination')" round small outline>
-            <v-icon left>close</v-icon>
+            <v-icon left>fas fa-times</v-icon>
             Termination Letter
           </v-btn>
         </v-layout>
@@ -110,12 +110,12 @@
     <v-card>
       <v-toolbar color="info" dense>
         <v-btn outline @click="downloadForm()" small round>
-          <v-icon left>cloud_download</v-icon>
+          <v-icon left>fas fa-cloud-download-alt</v-icon>
           Download Form
         </v-btn>
         <v-spacer></v-spacer>
         <v-btn icon outline @click="printDialog = false" small>
-          <v-icon>close</v-icon>
+          <v-icon>fas fa-times</v-icon>
         </v-btn>
       </v-toolbar>
         <eligibility
@@ -171,12 +171,12 @@
         </caseReport>
         <v-toolbar color="info" dense>
           <v-btn outline @click="downloadForm()" small round>
-            <v-icon left>cloud_download</v-icon>
+            <v-icon left>fas fa-cloud-download-alt</v-icon>
             Download Form
           </v-btn>
           <v-spacer></v-spacer>
           <v-btn icon outline @click="printDialog = false" small>
-            <v-icon>close</v-icon>
+            <v-icon>fas fa-times</v-icon>
           </v-btn>
         </v-toolbar>
       </v-card>

--- a/src/components/sub-components/login.vue
+++ b/src/components/sub-components/login.vue
@@ -6,7 +6,7 @@
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-btn small outline icon @click="deactivateSignIn()">
-        <v-icon>close</v-icon>
+        <v-icon>fas fa-times</v-icon>
       </v-btn>
     </v-toolbar>
     <v-card-text>
@@ -25,7 +25,7 @@
             label="Password"
             box
             v-model="login.pass"
-            :append-icon="showPass ? 'visibility_off' : 'visibility'"
+            :append-icon="showPass ? 'fas fa-eye-slash' : 'fas fa-eye'"
             @click:append="showPass = !showPass"
             :type="showPass ? 'text' : 'password'"
           ></v-text-field>
@@ -34,7 +34,7 @@
       <v-layout row wrap>
         <v-flex xs12 class="text-xs-right">
           <v-btn color="primary" @click="signIn()" outline round>
-            <v-icon left>navigate_next</v-icon>
+            <v-icon left>fas fa-chevron-right</v-icon>
             Login
           </v-btn>
         </v-flex>

--- a/src/components/sub-components/logout.vue
+++ b/src/components/sub-components/logout.vue
@@ -2,18 +2,18 @@
   <v-card>
     <v-toolbar color="primary" dark dense>
       <v-toolbar-title>
-        <v-icon left>contact_support</v-icon>
+        <v-icon left>fas fa-question-circle</i></v-icon>
         Are you sure you want to sign out?
       </v-toolbar-title>
     </v-toolbar>
     <v-card-text>
       <v-layout row wrap align-center justify-space-around>
           <v-btn color="secondary" @click="signOut()" round outline>
-            <v-icon left>check</v-icon>
+            <v-icon left>fas fa-check</v-icon>
             Sign out
           </v-btn>
           <v-btn color="red darken-4" dark @click="deactivateSignOut()" round outline>
-            <v-icon left>close</v-icon>
+            <v-icon left>fas fa-times</v-icon>
             Cancel
           </v-btn>
       </v-layout>

--- a/src/components/sub-components/notes.vue
+++ b/src/components/sub-components/notes.vue
@@ -3,7 +3,7 @@
     <v-layout row wrap>
       <v-flex xs12 class="text-xs-right">
         <v-btn color="primary" small  @click="addNote()" outline round>
-          <v-icon left>add_circle</v-icon>
+          <v-icon left>fas fa-plus-circle</v-icon>
           Add Note:
         </v-btn>
       </v-flex>
@@ -23,7 +23,7 @@
           </v-flex>
           <v-flex xs6 offset-xs3 class="text-xs-right">
             <v-btn color="primary" icon outline small @click="confirmDelete(index)">
-              <v-icon>close</v-icon>
+              <v-icon>fas fa-times</v-icon>
             </v-btn>
           </v-flex>
         </v-layout>
@@ -47,11 +47,11 @@
         </v-toolbar>
         <v-layout row wrap justify-space-around>
           <v-btn color="primary" outline @click="deleteNote()">
-            <v-icon left>check</v-icon>
+            <v-icon left>fas fa-check</v-icon>
             Yes
           </v-btn>
           <v-btn color="red darken-4" dark @click="deleteNoteModal = false">
-            <v-icon left>close</v-icon>
+            <v-icon left>fas fa-times</v-icon>
             No
           </v-btn>
         </v-layout>

--- a/src/components/sub-components/providerInfo.vue
+++ b/src/components/sub-components/providerInfo.vue
@@ -3,7 +3,7 @@
     <v-layout row wrap>
       <v-flex xs12 class="text-xs-right">
         <v-btn color="primary" outline small @click="addProvider()" round outline>
-          <v-icon left>add_circle</v-icon>
+          <v-icon left>fas fa-plus-circle</v-icon>
           Add Provider Info
         </v-btn>
       </v-flex>
@@ -15,7 +15,7 @@
             {{facility.name}}
             <v-spacer></v-spacer>
             <v-btn color="primary" icon outline small @click="confirmRemoval(index)">
-              <v-icon>close</v-icon>
+              <v-icon>fas fa-times</v-icon>
             </v-btn>
           </v-card-title>
           <v-divider inset></v-divider>
@@ -89,11 +89,11 @@
         <v-card-text>
           <v-layout row wrap justify-space-around>
             <v-btn color="primary" @click="deleteProvider()" outline round>
-              <v-icon left>check</v-icon>
+              <v-icon left>fas fa-check</v-icon>
               Yes
             </v-btn>
             <v-btn color="red darken-4" outline @click="confirmRemoveProvider = false" round>
-              <v-icon left>close</v-icon>
+              <v-icon left>fas fa-times</v-icon>
               No
             </v-btn>
           </v-layout>

--- a/src/components/sub-components/reports/downloadBar.vue
+++ b/src/components/sub-components/reports/downloadBar.vue
@@ -6,7 +6,7 @@
     </v-btn>
     <v-spacer></v-spacer>
     <v-btn small icon outline @click="closeReport()">
-      <v-icon>close</v-icon>
+      <v-icon>fas fa-times</v-icon>
     </v-btn>
   </v-toolbar>
 </template>

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import "./plugins/vuetify";
 import App from "./App.vue";
 import store from "@/store/store.js";
 import "roboto-fontface/css/roboto/roboto-fontface.css";
-import "material-design-icons-iconfont/dist/material-design-icons.css";
 import router from "@/router/router.js";
 
 //INPUT MASK FOR NON-VUETIFY INPUTS

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import Vuetify from "vuetify";
 import "vuetify/dist/vuetify.min.css";
+import '@fortawesome/fontawesome-free/css/all.css'
 
 Vue.use(Vuetify, {
   theme: {
@@ -11,7 +12,7 @@ Vue.use(Vuetify, {
     error: "#bfa89e",
     info: "#ebf5ee"
   },
-  iconfont: "md"
+  iconfont: "fa"
 });
 
 // https://coolors.co/78a1bb-394f49-ebf5ee-bfa89e-8b786d

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -60,7 +60,7 @@ export default {
     {
       item: "Dashboard",
       link: "/dashboard",
-      icon: "dashboard",
+      icon: "fas fa-columns",
       access: "user",
       color: "primary darken-1",
       dark: true
@@ -68,7 +68,7 @@ export default {
     {
       item: "New Case",
       link: "/new",
-      icon: "add_circle",
+      icon: "fas fa-plus-circle",
       access: "user",
       color: "secondary lighten-1",
       dark: true
@@ -76,7 +76,7 @@ export default {
     {
       item: "Search Case",
       link: "/search",
-      icon: "search",
+      icon: "fas fa-search",
       access: "user",
       color: "accent1",
       dark: false
@@ -92,7 +92,7 @@ export default {
     {
       item: "Run Reports",
       link: "/reports",
-      icon: "view_carousel",
+      icon: "fas fa-play",
       access: "user",
       color: "secondary lighten-3",
       dark: true
@@ -100,7 +100,7 @@ export default {
     {
       item: "About",
       link: "/about",
-      icon: "info",
+      icon: "fas fa-exclamation-circle",
       access: "all",
       color: "accent2",
       dark: true
@@ -108,7 +108,7 @@ export default {
     {
       item: "Admin",
       link: "/admin",
-      icon: "person_outline",
+      icon: "fas fa-user",
       access: "admin",
       color: "info",
       dark: false


### PR DESCRIPTION
Hi ,
I added this PR linking to this other issue

#23  

Also there were 4 icons that I didn't find exactly in font awesome, but I replaced them with the ones I consider fits the description/action in the UI. 

`<v-icon>settings_backup_restore</v-icon>   to  <v-icon>fas fa-undo-alt</v-icon> .  `

`<v-icon>view_carousel </v-icon>  to  <v-icon>fas fa-folder</v-icon> for the label Reports  `
`<v-icon>view_carousel </v-icon>  to  <v-icon>fas fa-play</v-icon> for the label Run Reports ` 

`<v-icon>dashboard </v-icon>   to <v-icon>fas fa-column</v-icon>  `

`<v-icon>cached </v-icon> to <v-icon>fas fa-sync</v-icon>`





Thanks! 